### PR TITLE
Feature#10

### DIFF
--- a/AutoReportWinApp/CalendarForm.cs
+++ b/AutoReportWinApp/CalendarForm.cs
@@ -26,14 +26,13 @@ namespace AutoReportWinApp
         }
 
         /// <summary>
-        /// カレンダーの日付が選択されたときのイベント
+        /// カレンダーフォームで日付が選択されたときのイベント
         /// </summary>
-        /// <remarks>入力日報フォームの「日付」項目に選択した日付文字列を出力</remarks>
+        /// <remarks>カレンダーフォームで選択された日付（文字列）を入力日報フォームの「日付」項目にセット</remarks>
         /// <param name="sender">イベントを送信したオブジェクト</param>
         /// <param name="e">カレンダーイベントに関わる引数</param>
         private void MousePointer_DataSelected(object sender, DateRangeEventArgs e)
         {
-            // カレンダーフォームで取得した日付文字列を入力日報フォームの「日付」項目に入れる
             this.inputDailyReportForm.Controls[inputCalenderDataFormItemName].Text = monthCalendar1.SelectionRange.Start.Date.ToString(dateFormat);
             this.Close();
         }

--- a/AutoReportWinApp/DailyReportDataListForm.Designer.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.Designer.cs
@@ -327,6 +327,7 @@
             // 
             this.bindingNavigatorPositionItem.AccessibleName = "位置";
             this.bindingNavigatorPositionItem.AutoSize = false;
+            this.bindingNavigatorPositionItem.Font = new System.Drawing.Font("Yu Gothic UI", 9F);
             this.bindingNavigatorPositionItem.Name = "bindingNavigatorPositionItem";
             this.bindingNavigatorPositionItem.Size = new System.Drawing.Size(50, 23);
             this.bindingNavigatorPositionItem.Text = "0";
@@ -344,7 +345,7 @@
             this.buttonMoveNextItemItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.buttonMoveNextItemItem.Name = "buttonMoveNextItemItem";
             this.buttonMoveNextItemItem.Size = new System.Drawing.Size(33, 22);
-            this.buttonMoveNextItemItem.Text = "後へ";
+            this.buttonMoveNextItemItem.Text = "次へ";
             this.buttonMoveNextItemItem.Click += new System.EventHandler(this.ButtonMoveNextItemItem_Click);
             // 
             // buttonMoveLastItem

--- a/AutoReportWinApp/DailyReportDataListForm.Designer.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.Designer.cs
@@ -52,13 +52,13 @@
             this.buttonSecondFolderDialog = new System.Windows.Forms.Button();
             this.bindingNavigator1 = new System.Windows.Forms.BindingNavigator(this.components);
             this.bindingNavigatorCountItem = new System.Windows.Forms.ToolStripLabel();
-            this.bindingNavigatorMoveFirstItem = new System.Windows.Forms.ToolStripButton();
-            this.bindingNavigatorMovePreviousItem = new System.Windows.Forms.ToolStripButton();
+            this.buttonMoveFirstItem = new System.Windows.Forms.ToolStripButton();
+            this.buttonMovePreviousItemItem = new System.Windows.Forms.ToolStripButton();
             this.bindingNavigatorSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.bindingNavigatorPositionItem = new System.Windows.Forms.ToolStripTextBox();
             this.bindingNavigatorSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.bindingNavigatorMoveNextItem = new System.Windows.Forms.ToolStripButton();
-            this.bindingNavigatorMoveLastItem = new System.Windows.Forms.ToolStripButton();
+            this.buttonMoveNextItemItem = new System.Windows.Forms.ToolStripButton();
+            this.buttonMoveLastItem = new System.Windows.Forms.ToolStripButton();
             this.bindingNavigatorSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.buttonAppendDailyReportData = new System.Windows.Forms.ToolStripButton();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
@@ -271,21 +271,21 @@
             this.bindingNavigator1.CountItem = this.bindingNavigatorCountItem;
             this.bindingNavigator1.DeleteItem = null;
             this.bindingNavigator1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.bindingNavigatorMoveFirstItem,
-            this.bindingNavigatorMovePreviousItem,
+            this.buttonMoveFirstItem,
+            this.buttonMovePreviousItemItem,
             this.bindingNavigatorSeparator,
             this.bindingNavigatorPositionItem,
             this.bindingNavigatorCountItem,
             this.bindingNavigatorSeparator1,
-            this.bindingNavigatorMoveNextItem,
-            this.bindingNavigatorMoveLastItem,
+            this.buttonMoveNextItemItem,
+            this.buttonMoveLastItem,
             this.bindingNavigatorSeparator2,
             this.buttonAppendDailyReportData});
             this.bindingNavigator1.Location = new System.Drawing.Point(0, 0);
-            this.bindingNavigator1.MoveFirstItem = this.bindingNavigatorMoveFirstItem;
-            this.bindingNavigator1.MoveLastItem = this.bindingNavigatorMoveLastItem;
-            this.bindingNavigator1.MoveNextItem = this.bindingNavigatorMoveNextItem;
-            this.bindingNavigator1.MovePreviousItem = this.bindingNavigatorMovePreviousItem;
+            this.bindingNavigator1.MoveFirstItem = null;
+            this.bindingNavigator1.MoveLastItem = null;
+            this.bindingNavigator1.MoveNextItem = null;
+            this.bindingNavigator1.MovePreviousItem = null;
             this.bindingNavigator1.Name = "bindingNavigator1";
             this.bindingNavigator1.PositionItem = this.bindingNavigatorPositionItem;
             this.bindingNavigator1.Size = new System.Drawing.Size(939, 25);
@@ -299,23 +299,24 @@
             this.bindingNavigatorCountItem.Text = "/ {0}";
             this.bindingNavigatorCountItem.ToolTipText = "項目の総数";
             // 
-            // bindingNavigatorMoveFirstItem
+            // buttonMoveFirstItem
             // 
-            this.bindingNavigatorMoveFirstItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.bindingNavigatorMoveFirstItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveFirstItem.Image")));
-            this.bindingNavigatorMoveFirstItem.Name = "bindingNavigatorMoveFirstItem";
-            this.bindingNavigatorMoveFirstItem.RightToLeftAutoMirrorImage = true;
-            this.bindingNavigatorMoveFirstItem.Size = new System.Drawing.Size(23, 22);
-            this.bindingNavigatorMoveFirstItem.Text = "最初に移動";
+            this.buttonMoveFirstItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.buttonMoveFirstItem.Image = ((System.Drawing.Image)(resources.GetObject("buttonMoveFirstItem.Image")));
+            this.buttonMoveFirstItem.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.buttonMoveFirstItem.Name = "buttonMoveFirstItem";
+            this.buttonMoveFirstItem.Size = new System.Drawing.Size(45, 22);
+            this.buttonMoveFirstItem.Text = "最初へ";
+            this.buttonMoveFirstItem.Click += new System.EventHandler(this.ButtonMoveFirstItem_Click);
             // 
-            // bindingNavigatorMovePreviousItem
+            // buttonMovePreviousItemItem
             // 
-            this.bindingNavigatorMovePreviousItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.bindingNavigatorMovePreviousItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMovePreviousItem.Image")));
-            this.bindingNavigatorMovePreviousItem.Name = "bindingNavigatorMovePreviousItem";
-            this.bindingNavigatorMovePreviousItem.RightToLeftAutoMirrorImage = true;
-            this.bindingNavigatorMovePreviousItem.Size = new System.Drawing.Size(23, 22);
-            this.bindingNavigatorMovePreviousItem.Text = "前に戻る";
+            this.buttonMovePreviousItemItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.buttonMovePreviousItemItem.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.buttonMovePreviousItemItem.Name = "buttonMovePreviousItemItem";
+            this.buttonMovePreviousItemItem.Size = new System.Drawing.Size(33, 22);
+            this.buttonMovePreviousItemItem.Text = "前へ";
+            this.buttonMovePreviousItemItem.Click += new System.EventHandler(this.ButtonMovePreviousItemItem_Click);
             // 
             // bindingNavigatorSeparator
             // 
@@ -326,7 +327,6 @@
             // 
             this.bindingNavigatorPositionItem.AccessibleName = "位置";
             this.bindingNavigatorPositionItem.AutoSize = false;
-            this.bindingNavigatorPositionItem.Font = new System.Drawing.Font("Yu Gothic UI", 9F);
             this.bindingNavigatorPositionItem.Name = "bindingNavigatorPositionItem";
             this.bindingNavigatorPositionItem.Size = new System.Drawing.Size(50, 23);
             this.bindingNavigatorPositionItem.Text = "0";
@@ -337,23 +337,25 @@
             this.bindingNavigatorSeparator1.Name = "bindingNavigatorSeparator1";
             this.bindingNavigatorSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
-            // bindingNavigatorMoveNextItem
+            // buttonMoveNextItemItem
             // 
-            this.bindingNavigatorMoveNextItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.bindingNavigatorMoveNextItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveNextItem.Image")));
-            this.bindingNavigatorMoveNextItem.Name = "bindingNavigatorMoveNextItem";
-            this.bindingNavigatorMoveNextItem.RightToLeftAutoMirrorImage = true;
-            this.bindingNavigatorMoveNextItem.Size = new System.Drawing.Size(23, 22);
-            this.bindingNavigatorMoveNextItem.Text = "次に移動";
+            this.buttonMoveNextItemItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.buttonMoveNextItemItem.Image = ((System.Drawing.Image)(resources.GetObject("buttonMoveNextItemItem.Image")));
+            this.buttonMoveNextItemItem.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.buttonMoveNextItemItem.Name = "buttonMoveNextItemItem";
+            this.buttonMoveNextItemItem.Size = new System.Drawing.Size(33, 22);
+            this.buttonMoveNextItemItem.Text = "後へ";
+            this.buttonMoveNextItemItem.Click += new System.EventHandler(this.ButtonMoveNextItemItem_Click);
             // 
-            // bindingNavigatorMoveLastItem
+            // buttonMoveLastItem
             // 
-            this.bindingNavigatorMoveLastItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.bindingNavigatorMoveLastItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveLastItem.Image")));
-            this.bindingNavigatorMoveLastItem.Name = "bindingNavigatorMoveLastItem";
-            this.bindingNavigatorMoveLastItem.RightToLeftAutoMirrorImage = true;
-            this.bindingNavigatorMoveLastItem.Size = new System.Drawing.Size(23, 22);
-            this.bindingNavigatorMoveLastItem.Text = "最後に移動";
+            this.buttonMoveLastItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.buttonMoveLastItem.Image = ((System.Drawing.Image)(resources.GetObject("buttonMoveLastItem.Image")));
+            this.buttonMoveLastItem.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.buttonMoveLastItem.Name = "buttonMoveLastItem";
+            this.buttonMoveLastItem.Size = new System.Drawing.Size(45, 22);
+            this.buttonMoveLastItem.Text = "最後へ";
+            this.buttonMoveLastItem.Click += new System.EventHandler(this.ButtonMoveLastItem_Click);
             // 
             // bindingNavigatorSeparator2
             // 
@@ -428,14 +430,14 @@
         private System.Windows.Forms.Button buttonSecondFolderDialog;
         private System.Windows.Forms.BindingNavigator bindingNavigator1;
         private System.Windows.Forms.ToolStripLabel bindingNavigatorCountItem;
-        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveFirstItem;
-        private System.Windows.Forms.ToolStripButton bindingNavigatorMovePreviousItem;
         private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator;
         private System.Windows.Forms.ToolStripTextBox bindingNavigatorPositionItem;
         private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator1;
-        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveNextItem;
-        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveLastItem;
         private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator2;
         private System.Windows.Forms.ToolStripButton buttonAppendDailyReportData;
+        private System.Windows.Forms.ToolStripButton buttonMoveFirstItem;
+        private System.Windows.Forms.ToolStripButton buttonMovePreviousItemItem;
+        private System.Windows.Forms.ToolStripButton buttonMoveNextItemItem;
+        private System.Windows.Forms.ToolStripButton buttonMoveLastItem;
     }
 }

--- a/AutoReportWinApp/DailyReportDataListForm.Designer.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.Designer.cs
@@ -28,6 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DailyReportDataListForm));
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.controlNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.date = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -38,21 +40,35 @@
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
-            this.button2 = new System.Windows.Forms.Button();
+            this.buttonOutputWeeklyReport = new System.Windows.Forms.Button();
             this.textBox3 = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.textBox1 = new System.Windows.Forms.TextBox();
-            this.buttonFolderDialog1 = new System.Windows.Forms.Button();
-            this.buttonDailyReportDataOutput = new System.Windows.Forms.Button();
+            this.buttonFirstFolderDialog = new System.Windows.Forms.Button();
+            this.buttonOutputDailyReportData = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
             this.textBox2 = new System.Windows.Forms.TextBox();
-            this.buttonFolderDialog2 = new System.Windows.Forms.Button();
+            this.buttonSecondFolderDialog = new System.Windows.Forms.Button();
+            this.bindingNavigator1 = new System.Windows.Forms.BindingNavigator(this.components);
+            this.bindingNavigatorCountItem = new System.Windows.Forms.ToolStripLabel();
+            this.bindingNavigatorMoveFirstItem = new System.Windows.Forms.ToolStripButton();
+            this.bindingNavigatorMovePreviousItem = new System.Windows.Forms.ToolStripButton();
+            this.bindingNavigatorSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.bindingNavigatorPositionItem = new System.Windows.Forms.ToolStripTextBox();
+            this.bindingNavigatorSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.bindingNavigatorMoveNextItem = new System.Windows.Forms.ToolStripButton();
+            this.bindingNavigatorMoveLastItem = new System.Windows.Forms.ToolStripButton();
+            this.bindingNavigatorSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.buttonAppendDailyReportData = new System.Windows.Forms.ToolStripButton();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingNavigator1)).BeginInit();
+            this.bindingNavigator1.SuspendLayout();
             this.SuspendLayout();
             // 
             // dataGridView1
             // 
+            this.dataGridView1.AllowUserToAddRows = false;
             this.dataGridView1.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
@@ -61,12 +77,12 @@
             this.impContent,
             this.scheContent,
             this.task});
-            this.dataGridView1.Location = new System.Drawing.Point(23, 14);
+            this.dataGridView1.Location = new System.Drawing.Point(12, 27);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowHeadersWidth = 51;
             this.dataGridView1.RowTemplate.Height = 24;
-            this.dataGridView1.Size = new System.Drawing.Size(900, 325);
+            this.dataGridView1.Size = new System.Drawing.Size(915, 325);
             this.dataGridView1.TabIndex = 0;
             this.dataGridView1.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ClickCreateData_CellDoubleClick);
             this.dataGridView1.CellMouseEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.DailyReportDataListFormDataGridView_CellMouseEnter);
@@ -107,7 +123,7 @@
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label4.Location = new System.Drawing.Point(504, 358);
+            this.label4.Location = new System.Drawing.Point(504, 377);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(129, 20);
             this.label4.TabIndex = 1;
@@ -117,7 +133,7 @@
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label5.Location = new System.Drawing.Point(504, 508);
+            this.label5.Location = new System.Drawing.Point(504, 518);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(139, 20);
             this.label5.TabIndex = 2;
@@ -127,7 +143,7 @@
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label6.Location = new System.Drawing.Point(802, 501);
+            this.label6.Location = new System.Drawing.Point(802, 511);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(110, 20);
             this.label6.TabIndex = 3;
@@ -137,28 +153,28 @@
             // 
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label7.Location = new System.Drawing.Point(504, 546);
+            this.label7.Location = new System.Drawing.Point(504, 558);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(261, 20);
             this.label7.TabIndex = 6;
             this.label7.Text = "※1～5つの管理番号選択可能";
             // 
-            // button2
+            // buttonOutputWeeklyReport
             // 
-            this.button2.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.button2.Location = new System.Drawing.Point(508, 580);
-            this.button2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(131, 40);
-            this.button2.TabIndex = 9;
-            this.button2.Text = "週報出力";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.ButtonOutputWeeklyReport_Click);
+            this.buttonOutputWeeklyReport.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.buttonOutputWeeklyReport.Location = new System.Drawing.Point(508, 590);
+            this.buttonOutputWeeklyReport.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.buttonOutputWeeklyReport.Name = "buttonOutputWeeklyReport";
+            this.buttonOutputWeeklyReport.Size = new System.Drawing.Size(131, 40);
+            this.buttonOutputWeeklyReport.TabIndex = 9;
+            this.buttonOutputWeeklyReport.Text = "週報出力";
+            this.buttonOutputWeeklyReport.UseVisualStyleBackColor = true;
+            this.buttonOutputWeeklyReport.Click += new System.EventHandler(this.ButtonOutputWeeklyReport_Click);
             // 
             // textBox3
             // 
             this.textBox3.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.textBox3.Location = new System.Drawing.Point(653, 498);
+            this.textBox3.Location = new System.Drawing.Point(653, 508);
             this.textBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBox3.Multiline = true;
             this.textBox3.Name = "textBox3";
@@ -169,7 +185,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label1.Location = new System.Drawing.Point(19, 358);
+            this.label1.Location = new System.Drawing.Point(19, 377);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(175, 20);
             this.label1.TabIndex = 12;
@@ -179,7 +195,7 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label2.Location = new System.Drawing.Point(19, 402);
+            this.label2.Location = new System.Drawing.Point(19, 416);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(148, 20);
             this.label2.TabIndex = 13;
@@ -188,41 +204,41 @@
             // textBox1
             // 
             this.textBox1.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.textBox1.Location = new System.Drawing.Point(173, 399);
+            this.textBox1.Location = new System.Drawing.Point(173, 413);
             this.textBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBox1.Name = "textBox1";
             this.textBox1.Size = new System.Drawing.Size(270, 27);
             this.textBox1.TabIndex = 14;
             // 
-            // buttonFolderDialog1
+            // buttonFirstFolderDialog
             // 
-            this.buttonFolderDialog1.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.buttonFolderDialog1.Location = new System.Drawing.Point(173, 439);
-            this.buttonFolderDialog1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.buttonFolderDialog1.Name = "buttonFolderDialog1";
-            this.buttonFolderDialog1.Size = new System.Drawing.Size(160, 40);
-            this.buttonFolderDialog1.TabIndex = 15;
-            this.buttonFolderDialog1.Text = "フォルダダイアログ";
-            this.buttonFolderDialog1.UseVisualStyleBackColor = true;
-            this.buttonFolderDialog1.Click += new System.EventHandler(this.ButtonFirstFolderDialog_Click);
+            this.buttonFirstFolderDialog.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.buttonFirstFolderDialog.Location = new System.Drawing.Point(173, 453);
+            this.buttonFirstFolderDialog.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.buttonFirstFolderDialog.Name = "buttonFirstFolderDialog";
+            this.buttonFirstFolderDialog.Size = new System.Drawing.Size(160, 40);
+            this.buttonFirstFolderDialog.TabIndex = 15;
+            this.buttonFirstFolderDialog.Text = "フォルダダイアログ";
+            this.buttonFirstFolderDialog.UseVisualStyleBackColor = true;
+            this.buttonFirstFolderDialog.Click += new System.EventHandler(this.ButtonFirstFolderDialog_Click);
             // 
-            // buttonDailyReportDataOutput
+            // buttonOutputDailyReportData
             // 
-            this.buttonDailyReportDataOutput.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.buttonDailyReportDataOutput.Location = new System.Drawing.Point(23, 498);
-            this.buttonDailyReportDataOutput.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.buttonDailyReportDataOutput.Name = "buttonDailyReportDataOutput";
-            this.buttonDailyReportDataOutput.Size = new System.Drawing.Size(80, 40);
-            this.buttonDailyReportDataOutput.TabIndex = 16;
-            this.buttonDailyReportDataOutput.Text = "出力";
-            this.buttonDailyReportDataOutput.UseVisualStyleBackColor = true;
-            this.buttonDailyReportDataOutput.Click += new System.EventHandler(this.ButtonOutputDailyReportData_Click);
+            this.buttonOutputDailyReportData.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.buttonOutputDailyReportData.Location = new System.Drawing.Point(23, 508);
+            this.buttonOutputDailyReportData.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.buttonOutputDailyReportData.Name = "buttonOutputDailyReportData";
+            this.buttonOutputDailyReportData.Size = new System.Drawing.Size(80, 40);
+            this.buttonOutputDailyReportData.TabIndex = 16;
+            this.buttonOutputDailyReportData.Text = "出力";
+            this.buttonOutputDailyReportData.UseVisualStyleBackColor = true;
+            this.buttonOutputDailyReportData.Click += new System.EventHandler(this.ButtonOutputDailyReportData_Click);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.label3.Location = new System.Drawing.Point(504, 399);
+            this.label3.Location = new System.Drawing.Point(504, 416);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(148, 20);
             this.label3.TabIndex = 17;
@@ -231,38 +247,144 @@
             // textBox2
             // 
             this.textBox2.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.textBox2.Location = new System.Drawing.Point(653, 396);
+            this.textBox2.Location = new System.Drawing.Point(653, 413);
             this.textBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBox2.Name = "textBox2";
             this.textBox2.Size = new System.Drawing.Size(270, 27);
             this.textBox2.TabIndex = 18;
             // 
-            // buttonFolderDialog2
+            // buttonSecondFolderDialog
             // 
-            this.buttonFolderDialog2.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.buttonFolderDialog2.Location = new System.Drawing.Point(653, 439);
-            this.buttonFolderDialog2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.buttonFolderDialog2.Name = "buttonFolderDialog2";
-            this.buttonFolderDialog2.Size = new System.Drawing.Size(160, 40);
-            this.buttonFolderDialog2.TabIndex = 19;
-            this.buttonFolderDialog2.Text = "フォルダダイアログ";
-            this.buttonFolderDialog2.UseVisualStyleBackColor = true;
-            this.buttonFolderDialog2.Click += new System.EventHandler(this.ButtonSecondFolderDialog_Click);
+            this.buttonSecondFolderDialog.Font = new System.Drawing.Font("MS UI Gothic", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.buttonSecondFolderDialog.Location = new System.Drawing.Point(653, 453);
+            this.buttonSecondFolderDialog.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.buttonSecondFolderDialog.Name = "buttonSecondFolderDialog";
+            this.buttonSecondFolderDialog.Size = new System.Drawing.Size(160, 40);
+            this.buttonSecondFolderDialog.TabIndex = 19;
+            this.buttonSecondFolderDialog.Text = "フォルダダイアログ";
+            this.buttonSecondFolderDialog.UseVisualStyleBackColor = true;
+            this.buttonSecondFolderDialog.Click += new System.EventHandler(this.ButtonSecondFolderDialog_Click);
+            // 
+            // bindingNavigator1
+            // 
+            this.bindingNavigator1.AddNewItem = null;
+            this.bindingNavigator1.CountItem = this.bindingNavigatorCountItem;
+            this.bindingNavigator1.DeleteItem = null;
+            this.bindingNavigator1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.bindingNavigatorMoveFirstItem,
+            this.bindingNavigatorMovePreviousItem,
+            this.bindingNavigatorSeparator,
+            this.bindingNavigatorPositionItem,
+            this.bindingNavigatorCountItem,
+            this.bindingNavigatorSeparator1,
+            this.bindingNavigatorMoveNextItem,
+            this.bindingNavigatorMoveLastItem,
+            this.bindingNavigatorSeparator2,
+            this.buttonAppendDailyReportData});
+            this.bindingNavigator1.Location = new System.Drawing.Point(0, 0);
+            this.bindingNavigator1.MoveFirstItem = this.bindingNavigatorMoveFirstItem;
+            this.bindingNavigator1.MoveLastItem = this.bindingNavigatorMoveLastItem;
+            this.bindingNavigator1.MoveNextItem = this.bindingNavigatorMoveNextItem;
+            this.bindingNavigator1.MovePreviousItem = this.bindingNavigatorMovePreviousItem;
+            this.bindingNavigator1.Name = "bindingNavigator1";
+            this.bindingNavigator1.PositionItem = this.bindingNavigatorPositionItem;
+            this.bindingNavigator1.Size = new System.Drawing.Size(939, 25);
+            this.bindingNavigator1.TabIndex = 20;
+            this.bindingNavigator1.Text = "bindingNavigator1";
+            // 
+            // bindingNavigatorCountItem
+            // 
+            this.bindingNavigatorCountItem.Name = "bindingNavigatorCountItem";
+            this.bindingNavigatorCountItem.Size = new System.Drawing.Size(29, 22);
+            this.bindingNavigatorCountItem.Text = "/ {0}";
+            this.bindingNavigatorCountItem.ToolTipText = "項目の総数";
+            // 
+            // bindingNavigatorMoveFirstItem
+            // 
+            this.bindingNavigatorMoveFirstItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.bindingNavigatorMoveFirstItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveFirstItem.Image")));
+            this.bindingNavigatorMoveFirstItem.Name = "bindingNavigatorMoveFirstItem";
+            this.bindingNavigatorMoveFirstItem.RightToLeftAutoMirrorImage = true;
+            this.bindingNavigatorMoveFirstItem.Size = new System.Drawing.Size(23, 22);
+            this.bindingNavigatorMoveFirstItem.Text = "最初に移動";
+            // 
+            // bindingNavigatorMovePreviousItem
+            // 
+            this.bindingNavigatorMovePreviousItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.bindingNavigatorMovePreviousItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMovePreviousItem.Image")));
+            this.bindingNavigatorMovePreviousItem.Name = "bindingNavigatorMovePreviousItem";
+            this.bindingNavigatorMovePreviousItem.RightToLeftAutoMirrorImage = true;
+            this.bindingNavigatorMovePreviousItem.Size = new System.Drawing.Size(23, 22);
+            this.bindingNavigatorMovePreviousItem.Text = "前に戻る";
+            // 
+            // bindingNavigatorSeparator
+            // 
+            this.bindingNavigatorSeparator.Name = "bindingNavigatorSeparator";
+            this.bindingNavigatorSeparator.Size = new System.Drawing.Size(6, 25);
+            // 
+            // bindingNavigatorPositionItem
+            // 
+            this.bindingNavigatorPositionItem.AccessibleName = "位置";
+            this.bindingNavigatorPositionItem.AutoSize = false;
+            this.bindingNavigatorPositionItem.Font = new System.Drawing.Font("Yu Gothic UI", 9F);
+            this.bindingNavigatorPositionItem.Name = "bindingNavigatorPositionItem";
+            this.bindingNavigatorPositionItem.Size = new System.Drawing.Size(50, 23);
+            this.bindingNavigatorPositionItem.Text = "0";
+            this.bindingNavigatorPositionItem.ToolTipText = "現在の場所";
+            // 
+            // bindingNavigatorSeparator1
+            // 
+            this.bindingNavigatorSeparator1.Name = "bindingNavigatorSeparator1";
+            this.bindingNavigatorSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
+            // bindingNavigatorMoveNextItem
+            // 
+            this.bindingNavigatorMoveNextItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.bindingNavigatorMoveNextItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveNextItem.Image")));
+            this.bindingNavigatorMoveNextItem.Name = "bindingNavigatorMoveNextItem";
+            this.bindingNavigatorMoveNextItem.RightToLeftAutoMirrorImage = true;
+            this.bindingNavigatorMoveNextItem.Size = new System.Drawing.Size(23, 22);
+            this.bindingNavigatorMoveNextItem.Text = "次に移動";
+            // 
+            // bindingNavigatorMoveLastItem
+            // 
+            this.bindingNavigatorMoveLastItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.bindingNavigatorMoveLastItem.Image = ((System.Drawing.Image)(resources.GetObject("bindingNavigatorMoveLastItem.Image")));
+            this.bindingNavigatorMoveLastItem.Name = "bindingNavigatorMoveLastItem";
+            this.bindingNavigatorMoveLastItem.RightToLeftAutoMirrorImage = true;
+            this.bindingNavigatorMoveLastItem.Size = new System.Drawing.Size(23, 22);
+            this.bindingNavigatorMoveLastItem.Text = "最後に移動";
+            // 
+            // bindingNavigatorSeparator2
+            // 
+            this.bindingNavigatorSeparator2.Name = "bindingNavigatorSeparator2";
+            this.bindingNavigatorSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // buttonAppendDailyReportData
+            // 
+            this.buttonAppendDailyReportData.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.buttonAppendDailyReportData.Image = ((System.Drawing.Image)(resources.GetObject("buttonAppendDailyReportData.Image")));
+            this.buttonAppendDailyReportData.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.buttonAppendDailyReportData.Name = "buttonAppendDailyReportData";
+            this.buttonAppendDailyReportData.Size = new System.Drawing.Size(109, 22);
+            this.buttonAppendDailyReportData.Text = "日報データ新規追加";
+            this.buttonAppendDailyReportData.Click += new System.EventHandler(this.ButtonAppendDailyReportData_Click);
             // 
             // DailyReportDataListForm
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(949, 631);
-            this.Controls.Add(this.buttonFolderDialog2);
+            this.ClientSize = new System.Drawing.Size(939, 641);
+            this.Controls.Add(this.bindingNavigator1);
+            this.Controls.Add(this.buttonSecondFolderDialog);
             this.Controls.Add(this.textBox2);
             this.Controls.Add(this.label3);
-            this.Controls.Add(this.buttonDailyReportDataOutput);
-            this.Controls.Add(this.buttonFolderDialog1);
+            this.Controls.Add(this.buttonOutputDailyReportData);
+            this.Controls.Add(this.buttonFirstFolderDialog);
             this.Controls.Add(this.textBox1);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.textBox3);
-            this.Controls.Add(this.button2);
+            this.Controls.Add(this.buttonOutputWeeklyReport);
             this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
@@ -274,6 +396,9 @@
             this.Text = "日報データリスト";
             this.Load += new System.EventHandler(this.DailyReportDataListForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingNavigator1)).EndInit();
+            this.bindingNavigator1.ResumeLayout(false);
+            this.bindingNavigator1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -286,7 +411,7 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Button buttonOutputWeeklyReport;
         private System.Windows.Forms.TextBox textBox3;
         private System.Windows.Forms.DataGridViewTextBoxColumn controlNum;
         private System.Windows.Forms.DataGridViewTextBoxColumn date;
@@ -296,10 +421,21 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox textBox1;
-        private System.Windows.Forms.Button buttonFolderDialog1;
-        private System.Windows.Forms.Button buttonDailyReportDataOutput;
+        private System.Windows.Forms.Button buttonFirstFolderDialog;
+        private System.Windows.Forms.Button buttonOutputDailyReportData;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.Button buttonFolderDialog2;
+        private System.Windows.Forms.Button buttonSecondFolderDialog;
+        private System.Windows.Forms.BindingNavigator bindingNavigator1;
+        private System.Windows.Forms.ToolStripLabel bindingNavigatorCountItem;
+        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveFirstItem;
+        private System.Windows.Forms.ToolStripButton bindingNavigatorMovePreviousItem;
+        private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator;
+        private System.Windows.Forms.ToolStripTextBox bindingNavigatorPositionItem;
+        private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator1;
+        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveNextItem;
+        private System.Windows.Forms.ToolStripButton bindingNavigatorMoveLastItem;
+        private System.Windows.Forms.ToolStripSeparator bindingNavigatorSeparator2;
+        private System.Windows.Forms.ToolStripButton buttonAppendDailyReportData;
     }
 }

--- a/AutoReportWinApp/DailyReportDataListForm.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using System.Data;
 
 namespace AutoReportWinApp
 {
@@ -29,6 +30,9 @@ namespace AutoReportWinApp
     public partial class DailyReportDataListForm : Form
     {
         private string csvDailyReportDataPath;
+        private int currentDailyReportDataIndex;
+        internal List<DailyReportEntity> dailyReportDataList;
+        private int pageCount;
 
         private static string tmpWeeklyReportStr = "【日付】" + Environment.NewLine +
                                                 "{RepFstStr}" + Environment.NewLine +
@@ -52,9 +56,12 @@ namespace AutoReportWinApp
         private static readonly string repScdStr = "{RepScdStr}";
         private static readonly string repThdStr = "{RepThdStr}";
         private static readonly string repFthStr = "{RepFthStr}";
+        private static readonly int pageSize = 3;
 
         public string CsvDailyReportDataPath { get => csvDailyReportDataPath; set => csvDailyReportDataPath = value; }
         public DataGridView DataGridView1 { get => this.dataGridView1; set => this.dataGridView1 = value; }
+        public int CurrentDailyReportDataIndex { get => this.currentDailyReportDataIndex; set => this.currentDailyReportDataIndex = value; }
+        public int PageCount { get => this.pageCount; set => this.pageCount = value; }
         public static string WinCharCode { get => winCharCode; }
 
         /// <summary>
@@ -65,6 +72,7 @@ namespace AutoReportWinApp
         {
             InitializeComponent();
             CsvDailyReportDataPath = this.GetCsvDailyReportDataPath();
+            this.dailyReportDataList = new List<DailyReportEntity>();
             this.InitDailyReportDataReader(CsvDailyReportDataPath);
         }
 
@@ -98,11 +106,10 @@ namespace AutoReportWinApp
                     // ヘッダーの有無
                     csv.Configuration.HasHeaderRecord = false;
                     // データ読み出し（IEnumerable<Item>として受け取る）
-                    var dailyReports = csv.GetRecords<DailyReportEntity>();
-                    foreach (DailyReportEntity dailyReport in dailyReports)
-                    {
-                        DataGridView1.Rows.Add(dailyReport.ControlNum, dailyReport.DateStr, DailyReportEntity.ReplaceToNewLineStr(dailyReport.ImplementationContent), DailyReportEntity.ReplaceToNewLineStr(dailyReport.TomorrowPlan), DailyReportEntity.ReplaceToNewLineStr(dailyReport.Task));
-                    }
+                    //var dailyReports = csv.GetRecords<DailyReportEntity>();
+                    this.dailyReportDataList = csv.GetRecords<DailyReportEntity>().ToList();
+                    CurrentDailyReportDataIndex = 0;
+                    SetPagingDailyReportDataToDataGridView(this.dailyReportDataList);
                 }
             }
             //日報データがない場合
@@ -114,6 +121,62 @@ namespace AutoReportWinApp
                     Directory.CreateDirectory(createDataDirectoryPath);
                 }
                 File.Create(csvDailyReportDataPath).Close();
+            }
+        }
+
+        /// <summary>
+        /// ページングしたデータをデータグリッドビューセット
+        /// </summary>
+        /// <param name="dailyReports">日報データリスト</param>
+        internal void SetPagingDailyReportDataToDataGridView(List<DailyReportEntity> dailyReports)
+        {
+            var dailyReportList = new List<List<DailyReportEntity>>();
+            int counter = 0;
+            var dailyReportsByPageSize = new List<DailyReportEntity>();
+            this.SetPageCountProperty(dailyReports);
+            foreach (DailyReportEntity dailyReport in dailyReports)
+            {
+                dailyReportsByPageSize.Add(dailyReport);
+                counter++;
+                if (counter % pageSize == 0)
+                {
+                    dailyReportList.Add(dailyReportsByPageSize);
+                    dailyReportsByPageSize = null;
+                    dailyReportsByPageSize = new List<DailyReportEntity>();
+                }
+                if (counter % pageSize != 0 & counter == dailyReports.Count)
+                {
+                    dailyReportList.Add(dailyReportsByPageSize);
+                }
+            }
+            if (dailyReportList.Count > 0)
+            {
+                DataGridView1.Rows.Clear();
+                foreach (DailyReportEntity dailyReport in dailyReportList.ToArray()[CurrentDailyReportDataIndex])
+                {
+                    DataGridView1.Rows.Add(dailyReport.ControlNum, dailyReport.DateStr, DailyReportEntity.ReplaceToNewLineStr(dailyReport.ImplementationContent), DailyReportEntity.ReplaceToNewLineStr(dailyReport.TomorrowPlan), DailyReportEntity.ReplaceToNewLineStr(dailyReport.Task));
+                }
+            }
+            this.bindingNavigatorCountItem.Text = InputDailyReportForm.SlashChar.ToString() + this.pageCount.ToString();
+            this.bindingNavigatorPositionItem.Text = (CurrentDailyReportDataIndex + 1).ToString();
+        }
+
+        /// <summary>
+        /// ページカウントプロパティーをセット
+        /// </summary>
+        /// <param name="dailyReports">日報データリスト</param>
+        internal void SetPageCountProperty(List<DailyReportEntity> dailyReports)
+        {
+            int dailyReportsCount = dailyReports.Count;
+            PageCount = 1;
+            if (dailyReportsCount > 0)
+            {
+                PageCount = dailyReportsCount / pageSize;
+                int calculateSurplus = dailyReportsCount % pageSize;
+                if (calculateSurplus != 0)
+                {
+                    PageCount++;
+                }
             }
         }
 
@@ -130,34 +193,41 @@ namespace AutoReportWinApp
                 using (var inputDailyReportForm = new InputDailyReportForm())
                 {
                     inputDailyReportForm.DailyReportDataListForm = this;
-                    inputDailyReportForm.CreateDataMode = CreateDataMode.APPEND;
-                    //日報データが1件以上ある場合
-                    if (DataGridView1.Rows.Count > 1)
-                    {
-                        //日報データ作成管理番号をプロパティにセット
-                        inputDailyReportForm.CreateDataControlNum = this.GetMaxDataGridControlNum(DataGridView1) + 1;
-                    }
-                    //日報データがない場合
-                    else
-                    {
-                        //日報データ作成管理番号をプロパティにセット
-                        inputDailyReportForm.CreateDataControlNum = createReportDataFirstColNum;
-                    }
-
-                    //日報データを更新する場合
-                    if (e.RowIndex != DataGridView1.Rows.Count - 1)
-                    {
-                        inputDailyReportForm.CreateDataMode = CreateDataMode.UPDATE;
-                        inputDailyReportForm.UpdateDataGridViewRowIndex = e.RowIndex;
-                        inputDailyReportForm.CreateDataControlNum = Int32.Parse(DataGridView1.Rows[e.RowIndex].Cells[0].Value.ToString());
-                        inputDailyReportForm.TextBox1Text = DataGridView1.Rows[e.RowIndex].Cells[1].Value.ToString();
-                        inputDailyReportForm.TextBox2Text = DataGridView1.Rows[e.RowIndex].Cells[2].Value.ToString();
-                        inputDailyReportForm.TextBox3Text = DataGridView1.Rows[e.RowIndex].Cells[3].Value.ToString();
-                        inputDailyReportForm.TextBox4Text = DataGridView1.Rows[e.RowIndex].Cells[4].Value.ToString();
-                    }
-
+                    inputDailyReportForm.CreateDataMode = CreateDataMode.UPDATE;
+                    inputDailyReportForm.CreateDataControlNum = Int32.Parse(DataGridView1.Rows[e.RowIndex].Cells[0].Value.ToString());
+                    inputDailyReportForm.TextBox1Text = DataGridView1.Rows[e.RowIndex].Cells[1].Value.ToString();
+                    inputDailyReportForm.TextBox2Text = DataGridView1.Rows[e.RowIndex].Cells[2].Value.ToString();
+                    inputDailyReportForm.TextBox3Text = DataGridView1.Rows[e.RowIndex].Cells[3].Value.ToString();
+                    inputDailyReportForm.TextBox4Text = DataGridView1.Rows[e.RowIndex].Cells[4].Value.ToString();
                     inputDailyReportForm.ShowDialog();
                 }
+            }
+        }
+
+        /// <summary>
+        ///「日報データ新規追加」ボタン押下時、イベント
+        /// </summary>
+        /// <param name="sender">イベントを送信したオブジェクト</param>
+        /// <param name="e">データグリッドビューイベントに関わる引数</param>
+        private void ButtonAppendDailyReportData_Click(object sender, EventArgs e)
+        {
+            using (var inputDailyReportForm = new InputDailyReportForm())
+            {
+                inputDailyReportForm.DailyReportDataListForm = this;
+                inputDailyReportForm.CreateDataMode = CreateDataMode.APPEND;
+                //日報データが1件以上ある場合
+                if (this.dailyReportDataList.Count > 0)
+                {
+                    //日報データ作成管理番号をプロパティにセット
+                    inputDailyReportForm.CreateDataControlNum = this.GetMaxControlNum(this.dailyReportDataList) + 1;
+                }
+                //日報データがない場合
+                else
+                {
+                    //日報データ作成管理番号をプロパティにセット
+                    inputDailyReportForm.CreateDataControlNum = createReportDataFirstColNum;
+                }
+                inputDailyReportForm.ShowDialog();
             }
         }
 
@@ -165,19 +235,16 @@ namespace AutoReportWinApp
         /// 日報データリストの最大管理番号取得
         /// </summary>
         /// <remarks>日報データ新規作成時、必要</remarks>
-        /// <param name="dataGridView">データグリッドビューオブジェクト</param>
+        /// <param name="dailyReports">日報データリスト</param>
         /// <returns>最大管理番号</returns>
-        private int GetMaxDataGridControlNum(DataGridView dataGridView)
+        private int GetMaxControlNum(List<DailyReportEntity> dailyReports)
         {
-            var dataGridViewControlNumList = new List<int>();
-            foreach (var row in DataGridView1.Rows.Cast<DataGridViewRow>())
+            var controlNumList = new List<int>();
+            foreach (var dailyReport in dailyReports)
             {
-                if (row.Cells[0].Value != null)
-                {
-                    dataGridViewControlNumList.Add(Int32.Parse(row.Cells[0].Value.ToString()));
-                }
+                controlNumList.Add(Int32.Parse(dailyReport.ControlNum));
             }
-            return dataGridViewControlNumList.Max();
+            return controlNumList.Max();
         }
 
         /// <summary>
@@ -377,16 +444,16 @@ namespace AutoReportWinApp
             {
                 string[] controlNumArray = this.textBox3.Text.Split(delimiter);
                 var outputWeeklyReportDataList = new List<DailyReportEntity>();
-                foreach (var row in DataGridView1.Rows.Cast<DataGridViewRow>())
+                foreach (var dailyReportData in this.dailyReportDataList)
                 {
-                    if (row.Cells[0].Value != null && controlNumArray.Contains(row.Cells[0].Value.ToString()))
+                    if (controlNumArray.Contains(dailyReportData.ControlNum))
                     {
                         var reportData = new DailyReportEntity();
-                        reportData.ControlNum = row.Cells[0].Value.ToString();
-                        reportData.DateStr = row.Cells[1].Value.ToString();
-                        reportData.ImplementationContent = row.Cells[2].Value.ToString();
-                        reportData.TomorrowPlan = row.Cells[3].Value.ToString();
-                        reportData.Task = row.Cells[4].Value.ToString();
+                        reportData.ControlNum = dailyReportData.ControlNum;
+                        reportData.DateStr = dailyReportData.DateStr;
+                        reportData.ImplementationContent = dailyReportData.ImplementationContent;
+                        reportData.TomorrowPlan = dailyReportData.Task;
+                        reportData.Task = dailyReportData.TomorrowPlan;
                         outputWeeklyReportDataList.Add(reportData);
                     }
                 }
@@ -484,7 +551,7 @@ namespace AutoReportWinApp
                     errMsg.Append(Properties.Resources.E0005);
                 }
 
-                if (!ContainDataGridViewDataCheck(this.textBox3.Text.Split(delimiter)))
+                if (!ContainDailyReportDataDataCheck(this.textBox3.Text.Split(delimiter)))
                 {
                     if (errMsg.Length > 0)
                     {
@@ -528,19 +595,16 @@ namespace AutoReportWinApp
         /// <remarks>選択された対象管理番号がデータリストに存在しているかチェック</remarks>
         /// <param name="array">配列</param>
         /// <returns>判定結果</returns>
-        private Boolean ContainDataGridViewDataCheck(string[] array)
+        private Boolean ContainDailyReportDataDataCheck(string[] array)
         {
-            var dataGridViewControlNumList = new List<String>();
-            foreach (var row in DataGridView1.Rows.Cast<DataGridViewRow>())
+            var dataControlNumList = new List<String>();
+            foreach (var dailyReportData in this.dailyReportDataList)
             {
-                if (row.Cells[0].Value != null)
-                {
-                    dataGridViewControlNumList.Add(row.Cells[0].Value.ToString());
-                }
+                dataControlNumList.Add(dailyReportData.ControlNum);
             }
             foreach (var element in array)
             {
-                if (dataGridViewControlNumList.Contains(element))
+                if (dataControlNumList.Contains(element))
                 {
                     continue;
                 }
@@ -552,6 +616,7 @@ namespace AutoReportWinApp
             return true;
         }
 
+        /// <summary>
         /// データグリッドビューマウスポインターがセルに入ったときのイベント
         /// </summary>
         /// <remarks>データグリッドビューの「日付」、「実施内容」、「翌日予定」、「課題」項目データのセルにマウスポインターが入ったとき、データグリッドビューのスタイルを変更</remarks>

--- a/AutoReportWinApp/DailyReportDataListForm.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.cs
@@ -255,7 +255,14 @@ namespace AutoReportWinApp
         /// <param name="e">イベントに関わる引数</param>
         private void DailyReportDataListForm_Load(object sender, EventArgs e)
         {
-            //データグリッドビューフォーカスをクリア
+            this.ClearDataGridViewFocus();
+        }
+
+        /// <summary>
+        /// データグリッドビューフォーカスをクリア
+        /// </summary>
+        private void ClearDataGridViewFocus()
+        {
             this.Activate();
             this.dataGridView1.CurrentCell = null;
             this.dataGridView1.RowHeadersVisible = false;
@@ -642,6 +649,63 @@ namespace AutoReportWinApp
             {
                 ChangeDataGridViewStyle(e, Color.Empty, Cursors.Default);
             }
+        }
+
+        /// <summary>
+        ///「先頭ページ移動」ボタン押下時、イベント
+        /// </summary>
+        /// <param name="sender">イベントを送信したオブジェクト</param>
+        /// <param name="e">データグリッドビューイベントに関わる引数</param>
+        private void ButtonMoveFirstItem_Click(object sender, EventArgs e)
+        {
+            CurrentDailyReportDataIndex = 0;
+            SetPagingDailyReportDataToDataGridView(this.dailyReportDataList);
+            this.ClearDataGridViewFocus();
+        }
+
+        /// <summary>
+        ///「最終ページ移動」ボタン押下時、イベント
+        /// </summary>
+        /// <param name="sender">イベントを送信したオブジェクト</param>
+        /// <param name="e">データグリッドビューイベントに関わる引数</param>
+        private void ButtonMoveLastItem_Click(object sender, EventArgs e)
+        {
+            if (PageCount > 1)
+            {
+                CurrentDailyReportDataIndex = PageCount - 1;
+            }
+            SetPagingDailyReportDataToDataGridView(this.dailyReportDataList);
+            this.ClearDataGridViewFocus();
+        }
+
+        /// <summary>
+        ///「次ページ移動」ボタン押下時、イベント
+        /// </summary>
+        /// <param name="sender">イベントを送信したオブジェクト</param>
+        /// <param name="e">データグリッドビューイベントに関わる引数</param>
+        private void ButtonMoveNextItemItem_Click(object sender, EventArgs e)
+        {
+            if (CurrentDailyReportDataIndex < PageCount - 1)
+            {
+                CurrentDailyReportDataIndex++;
+            }
+            SetPagingDailyReportDataToDataGridView(this.dailyReportDataList);
+            this.ClearDataGridViewFocus();
+        }
+
+        /// <summary>
+        ///「前ページ移動」ボタン押下時、イベント
+        /// </summary>
+        /// <param name="sender">イベントを送信したオブジェクト</param>
+        /// <param name="e">データグリッドビューイベントに関わる引数</param>
+        private void ButtonMovePreviousItemItem_Click(object sender, EventArgs e)
+        {
+            if (CurrentDailyReportDataIndex > 0)
+            {
+                CurrentDailyReportDataIndex--;
+            }
+            SetPagingDailyReportDataToDataGridView(this.dailyReportDataList);
+            this.ClearDataGridViewFocus();
         }
     }
 }

--- a/AutoReportWinApp/DailyReportDataListForm.cs
+++ b/AutoReportWinApp/DailyReportDataListForm.cs
@@ -442,9 +442,9 @@ namespace AutoReportWinApp
                         var reportData = new DailyReportEntity();
                         reportData.ControlNum = dailyReportData.ControlNum;
                         reportData.DateStr = dailyReportData.DateStr;
-                        reportData.ImplementationContent = dailyReportData.ImplementationContent;
-                        reportData.TomorrowPlan = dailyReportData.Task;
-                        reportData.Task = dailyReportData.TomorrowPlan;
+                        reportData.ImplementationContent = DailyReportEntity.ReplaceToNewLineStr(dailyReportData.ImplementationContent);
+                        reportData.TomorrowPlan = DailyReportEntity.ReplaceToNewLineStr(dailyReportData.Task);
+                        reportData.Task = DailyReportEntity.ReplaceToNewLineStr(dailyReportData.TomorrowPlan);
                         outputWeeklyReportDataList.Add(reportData);
                     }
                 }

--- a/AutoReportWinApp/DailyReportDataListForm.resx
+++ b/AutoReportWinApp/DailyReportDataListForm.resx
@@ -132,4 +132,78 @@
   <metadata name="task.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="controlNum.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="date.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="impContent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="scheContent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="task.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="bindingNavigator1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="bindingNavigatorMoveFirstItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAASpJREFUOE9jGDygcNbz/00Lnv/PnPj4P1QIA4S3P8Apx5A789n/VUfe/8elKL77
+        wf/ghmu4DciY8vT/wn0fsCqK73n4f+n+///9qy/gNiCh58n/aVveYyiKaL8P1pw56/9/r9ITuA2I7Hr0
+        v3f1BxRFoa33wJpb1wFt7/z73yX/AG4DApsf/q+b/w6uKLjl7v9Fe///7wBqzpjz879d3c//9hnbcRvg
+        UXX/f/60NyiK7Ipv/0+f8/u/f9e3/zqF7/5bJKzHbYB96d3/2ZNfYyjSTzn/36ToxX+VrE//jSOX4TbA
+        Iu/O/9T+11gVGSSd+C+b9vW/bvA83AYYZt3+H9byEqci/dTL/zV8p+E2QCftxn+/6od4Fal4TMBtgFPu
+        lf8gBXgVDULAwAAA8HbAq6XlmnAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="bindingNavigatorMovePreviousItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALZJREFUOE9jGDogvP3BfyiTdBDf/eB/cMM18gyI73n4f+n+///9qy+QbkBE+32w
+        5sxZ//97lZ4gzYDQ1ntgza3rgLZ3/v3vkn+AeAOCW+7+X7T3//8OoOaMOT//29X9/G+fsZ00F9gV3/6f
+        Puf3f/+ub/91Ct/9t0hYT3oY6Kec/29S9OK/Stan/8aRy0g3AAQMkk78l037+l83eB55BoCAfurl/xq+
+        08g3AARUPCZQZsBgBQwMANAUYJgEulBVAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="bindingNavigatorMoveNextItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAKNJREFUOE9jGHygcNbz/1AmeSB35rP/Cd33yDckY8rT//P2//6f0HWHPEMSep78
+        n73v1//OrX//u5VeJt2QyK5H/6ds+/W/ZOnf/wnT//63yT1LmiGBzQ//t659D9ZsXPLlv3T0tf/GkcuI
+        N8Sj6v7/krnv4JoVXXpIc4F96d3/gS3PyNMMAhZ5d/7bFFwhTzMIGGbdJl8zCOik3SBf81AEDAwAoH5f
+        oAc0QjgAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="bindingNavigatorMoveLastItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAASxJREFUOE9jGFygcNbz/1AmBgDJNS14/j9z4mOcahhyZz77n9B9D6sCkNyqI+//
+        h7c/wG1AxpSn/+ft//0/oesOhiKQ3MJ9H/4HN1zDbUBCz5P/s/f9+t+59e9/t9LLKApBctO2vP/vX30B
+        twGRXY/+T9n263/J0r//E6b//W+TexauGCTXu/rDf6/SE7gNCGx++L917XuwZuOSL/+lo6/9N45cBtYA
+        kqub/+6/S/4B3AZ4VN3/XzL3HVyzoksPXDFILn/am//2GdtxG2Bfevd/YMszDM0gAJLLnvz6v0XCetwG
+        WOTd+W9TcAVDMwiA5FL7X8O9hBUYZt3GqhkEQHJhLS//6wbPw22ATtoNnJIgOb/qh/81fKfhNgAfcMq9
+        8l/FYwIYQ4UGBWBgAAC+0b+zuQxOnAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="buttonAppendDailyReportData.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>

--- a/AutoReportWinApp/DailyReportDataListForm.resx
+++ b/AutoReportWinApp/DailyReportDataListForm.resx
@@ -132,63 +132,53 @@
   <metadata name="task.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="controlNum.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="date.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="impContent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="scheContent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="task.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="bindingNavigator1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="bindingNavigatorMoveFirstItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="buttonMoveFirstItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAASpJREFUOE9jGDygcNbz/00Lnv/PnPj4P1QIA4S3P8Apx5A789n/VUfe/8elKL77
-        wf/ghmu4DciY8vT/wn0fsCqK73n4f+n+///9qy/gNiCh58n/aVveYyiKaL8P1pw56/9/r9ITuA2I7Hr0
-        v3f1BxRFoa33wJpb1wFt7/z73yX/AG4DApsf/q+b/w6uKLjl7v9Fe///7wBqzpjz879d3c//9hnbcRvg
-        UXX/f/60NyiK7Ipv/0+f8/u/f9e3/zqF7/5bJKzHbYB96d3/2ZNfYyjSTzn/36ToxX+VrE//jSOX4TbA
-        Iu/O/9T+11gVGSSd+C+b9vW/bvA83AYYZt3+H9byEqci/dTL/zV8p+E2QCftxn+/6od4Fal4TMBtgFPu
-        lf8gBXgVDULAwAAA8HbAq6XlmnAAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="bindingNavigatorMovePreviousItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="buttonMoveNextItemItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAALZJREFUOE9jGDogvP3BfyiTdBDf/eB/cMM18gyI73n4f+n+///9qy+QbkBE+32w
-        5sxZ//97lZ4gzYDQ1ntgza3rgLZ3/v3vkn+AeAOCW+7+X7T3//8OoOaMOT//29X9/G+fsZ00F9gV3/6f
-        Puf3f/+ub/91Ct/9t0hYT3oY6Kec/29S9OK/Stan/8aRy0g3AAQMkk78l037+l83eB55BoCAfurl/xq+
-        08g3AARUPCZQZsBgBQwMANAUYJgEulBVAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="bindingNavigatorMoveNextItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="buttonMoveLastItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAKNJREFUOE9jGHygcNbz/1AmeSB35rP/Cd33yDckY8rT//P2//6f0HWHPEMSep78
-        n73v1//OrX//u5VeJt2QyK5H/6ds+/W/ZOnf/wnT//63yT1LmiGBzQ//t659D9ZsXPLlv3T0tf/GkcuI
-        N8Sj6v7/krnv4JoVXXpIc4F96d3/gS3PyNMMAhZ5d/7bFFwhTzMIGGbdJl8zCOik3SBf81AEDAwAoH5f
-        oAc0QjgAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="bindingNavigatorMoveLastItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAASxJREFUOE9jGFygcNbz/1AmBgDJNS14/j9z4mOcahhyZz77n9B9D6sCkNyqI+//
-        h7c/wG1AxpSn/+ft//0/oesOhiKQ3MJ9H/4HN1zDbUBCz5P/s/f9+t+59e9/t9LLKApBctO2vP/vX30B
-        twGRXY/+T9n263/J0r//E6b//W+TexauGCTXu/rDf6/SE7gNCGx++L917XuwZuOSL/+lo6/9N45cBtYA
-        kqub/+6/S/4B3AZ4VN3/XzL3HVyzoksPXDFILn/am//2GdtxG2Bfevd/YMszDM0gAJLLnvz6v0XCetwG
-        WOTd+W9TcAVDMwiA5FL7X8O9hBUYZt3GqhkEQHJhLS//6wbPw22ATtoNnJIgOb/qh/81fKfhNgAfcMq9
-        8l/FYwIYQ4UGBWBgAAC+0b+zuQxOnAAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="buttonAppendDailyReportData.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/AutoReportWinApp/DailyReportEntity.cs
+++ b/AutoReportWinApp/DailyReportEntity.cs
@@ -7,11 +7,9 @@ namespace AutoReportWinApp
     /// <summary>
     /// 日報データエンティティクラス
     /// </summary>
-    /// <remarks>日報データ用クラス</remarks>
+    /// <remarks>日報データクラス</remarks>
     class DailyReportEntity
     {
-        //csvファイルを読み込み、日報データを表示している
-        //以下csvファイル用の改行文字列とする
         private static readonly string userNewLineStr = "@NewLine";
         private static readonly string newLineStr = "\r\n";
 
@@ -35,7 +33,7 @@ namespace AutoReportWinApp
         /// <returns>置換後文字列</returns>
         public static string ReplaceToNewLineStr(string strWithUserNewLine)
         {
-            string rtnStr = strWithUserNewLine;
+            var rtnStr = strWithUserNewLine;
             if (rtnStr.Contains(userNewLineStr))
             {
                 rtnStr = rtnStr.Replace(userNewLineStr, NewLineStr);
@@ -50,7 +48,7 @@ namespace AutoReportWinApp
         /// <returns>置換後文字列</returns>
         public static string ReplaceToUserNewLineStr(string strWithNewLine)
         {
-            string rtnStr = strWithNewLine;
+            var rtnStr = strWithNewLine;
             if (rtnStr.Contains(NewLineStr))
             {
                 rtnStr = rtnStr.Replace(NewLineStr, userNewLineStr);

--- a/AutoReportWinApp/InputDailyReportForm.Designer.cs
+++ b/AutoReportWinApp/InputDailyReportForm.Designer.cs
@@ -148,7 +148,7 @@
             this.buttonCreate.TabIndex = 9;
             this.buttonCreate.Text = "データ作成";
             this.buttonCreate.UseVisualStyleBackColor = true;
-            this.buttonCreate.Click += new System.EventHandler(this.ButtonCreateData_Click);
+            this.buttonCreate.Click += new System.EventHandler(this.ButtonCreate_Click);
             // 
             // buttonForDataList
             // 
@@ -161,7 +161,7 @@
             this.buttonForDataList.TabIndex = 10;
             this.buttonForDataList.Text = "データリストへ";
             this.buttonForDataList.UseVisualStyleBackColor = true;
-            this.buttonForDataList.Click += new System.EventHandler(this.ButtonToDailyReportDataListForm_Click);
+            this.buttonForDataList.Click += new System.EventHandler(this.ButtonForDataList_Click);
             // 
             // label5
             // 


### PR DESCRIPTION
お手数おかけしますがご確認よろしくお願いします。
ユーザービリティで考えると今回ページング機能と日報データの項目で昇順か降順に並び替える機能をつけるとより使いやすくなるのではないかなと思いました。
具体的には、以下イメージしております。
データグリッドビューでヘッダー項目をクリックすると昇順か降順に日報データが並び変わる。
データグリッドビューを並び替えたとき、元のcsvファイルの日報データも並び替えるか並び替えないか。
ご意見お聞きしたいです。